### PR TITLE
Fix compatibility with python3.12+

### DIFF
--- a/versioneer.py
+++ b/versioneer.py
@@ -339,9 +339,14 @@ def get_config_from_root(root):
     # configparser.NoOptionError (if it lacks "VCS="). See the docstring at
     # the top of versioneer.py for instructions on writing your setup.cfg .
     setup_cfg = os.path.join(root, "setup.cfg")
-    parser = configparser.SafeConfigParser()
-    with open(setup_cfg, "r") as f:
-        parser.readfp(f)
+    try:
+        parser = configparser.SafeConfigParser()
+        with open(setup_cfg, "r") as f:
+            parser.readfp(f)
+    except AttributeError:
+        parser = configparser.ConfigParser()
+        with open(setup_cfg, "r") as f:
+            parser.read_file(f)
     VCS = parser.get("versioneer", "VCS")  # mandatory
 
     def get(parser, name):


### PR DESCRIPTION
`configparser.SafeConfigParser` is deprecated since Python3.2 (python/cpython#89336).