### PR TITLE
Clarify Documentation for Task Deletion Parameters

### DIFF
--- a/qarnot/task.py
+++ b/qarnot/task.py
@@ -350,10 +350,10 @@ class Task(object):
     def delete(self, purge_resources: bool = False, purge_results: bool = False) -> None:
         """Delete this task on the server.
 
-        :param bool purge_resources: parameter value is used to determine if the bucket is also deleted.
+        :param bool purge_resources: parameter value is used to determine if the resources bucket is also deleted.
                 Defaults to False.
 
-        :param bool purge_results: parameter value is used to determine if the bucket is also deleted.
+        :param bool purge_results: parameter value is used to determine if the results (output) bucket is also deleted.
                 Defaults to False.
 
         :raises ~qarnot.exceptions.QarnotGenericException: API general error, see message for details


### PR DESCRIPTION
### PR Description

This PR updates the docstring for the `delete` method to provide clearer explanations for the `purge_resources` and `purge_results` parameters. 

#### Changes:
- Clarified that `purge_resources` refers to the deletion of the resources bucket.
- Clarified that `purge_results` refers to the deletion of the results (output) bucket.

These changes improve readability and eliminate ambiguity in the documentation.